### PR TITLE
Fix Gradio queue concurrency argument

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -8,6 +8,7 @@ indirmesine olanak tanır.
 
 from __future__ import annotations
 
+import inspect
 import os
 from datetime import datetime
 from typing import Optional
@@ -165,7 +166,16 @@ def launch():
     """Arayüzü başlat."""
 
     demo = build_interface()
-    demo.queue(concurrency_count=1).launch()
+
+    queue_kwargs = {}
+    queue_params = inspect.signature(gr.Blocks.queue).parameters
+
+    if "default_concurrency_limit" in queue_params:
+        queue_kwargs["default_concurrency_limit"] = 1
+    elif "concurrency_count" in queue_params:
+        queue_kwargs["concurrency_count"] = 1
+
+    demo.queue(**queue_kwargs).launch()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- detect the supported concurrency argument for `gr.Blocks.queue`
- set the concurrency limit in a backwards-compatible way when launching the UI

## Testing
- python -m compileall ui.py

------
https://chatgpt.com/codex/tasks/task_b_68cc1895cfa0832f8ac1aba09a519ca1