### PR TITLE
Improve report planner JSON handling

### DIFF
--- a/debug_test.py
+++ b/debug_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Debug test - planlama aşamasını test eder"""
+
+import asyncio
+from main_report_agent import MainReportAgent
+
+
+async def debug_planning():
+    """Sadece planlama aşamasını test et"""
+    print("🔍 Debug test başlatılıyor...")
+
+    agent = MainReportAgent()
+
+    # Test planlama
+    topic = "Yapay zeka ajanlarının üretim firmalarında kullanım alanları"
+
+    messages = agent.planner_prompt.format_messages(
+        topic=topic,
+        research_data="Test araştırma verisi"
+    )
+
+    print("📝 Gönderilen prompt:")
+    for msg in messages:
+        print(f"Role: {msg.__class__.__name__}")
+        print(f"Content: {msg.content}")
+        print("-" * 50)
+
+    try:
+        response = await agent.llm.ainvoke(messages)
+        print("🤖 Model yanıtı:")
+        print(response.content)
+        print("=" * 70)
+
+        # Parser test
+        from json_parser_fix import parse_json_from_response
+
+        result = parse_json_from_response(response.content)
+        print("✅ Parse edilmiş JSON:")
+        import json
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+
+    except Exception as e:
+        print(f"❌ Hata: {e}")
+        import traceback
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    asyncio.run(debug_planning())

--- a/json_parser_fix.py
+++ b/json_parser_fix.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""JSON Parser düzeltmesi - plan_report fonksiyonunda kullanılacak"""
+
+import json
+import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_json_from_response(response_content: str) -> dict:
+    """Model yanıtından JSON'ı güvenli şekilde çıkarır"""
+
+    try:
+        content = response_content.strip()
+        logger.info(f"Ham model yanıtı (ilk 300 karakter): {content[:300]}")
+
+        # Metod 1: Doğrudan JSON parse etmeyi dene
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            pass
+
+        # Metod 2: İlk { ile son } arasını al
+        json_start = content.find('{')
+        json_end = content.rfind('}') + 1
+
+        if json_start != -1 and json_end > json_start:
+            json_str = content[json_start:json_end]
+            logger.info(f"Çıkarılan JSON: {json_str}")
+            try:
+                return json.loads(json_str)
+            except json.JSONDecodeError:
+                pass
+
+        # Metod 3: Regex ile JSON bloğunu bul
+        json_pattern = r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}'
+        matches = re.findall(json_pattern, content, re.DOTALL)
+
+        for match in matches:
+            try:
+                # Çok satırlı JSON'ları temizle
+                cleaned_match = re.sub(r'\n\s*', ' ', match)
+                return json.loads(cleaned_match)
+            except json.JSONDecodeError:
+                continue
+
+        # Metod 4: JSON'ı satır satır temizle
+        lines = content.split('\n')
+        json_lines = []
+        in_json = False
+        brace_count = 0
+
+        for line in lines:
+            stripped = line.strip()
+            if not in_json and stripped.startswith('{'):
+                in_json = True
+                json_lines.append(stripped)
+                brace_count += stripped.count('{') - stripped.count('}')
+            elif in_json:
+                json_lines.append(stripped)
+                brace_count += stripped.count('{') - stripped.count('}')
+                if brace_count <= 0:
+                    break
+
+        if json_lines:
+            json_str = ' '.join(json_lines)
+            try:
+                return json.loads(json_str)
+            except json.JSONDecodeError:
+                pass
+
+        # Hiçbir metod çalışmadı
+        raise ValueError("JSON formatı hiçbir metod ile parse edilemedi")
+
+    except Exception as e:
+        logger.error(f"JSON parsing hatası: {e}")
+        logger.error(f"İşlenmeye çalışılan içerik: {response_content}")
+        raise
+
+
+def create_fallback_structure(topic: str) -> dict:
+    """Fallback rapor yapısı oluştur"""
+    return {
+        "title": f"{topic} - Detaylı Araştırma Raporu",
+        "sections": [
+            {
+                "name": "Giriş ve Kapsam",
+                "description": f"{topic} konusunun tanıtımı, araştırmanın kapsamı ve amaçları",
+                "research": False
+            },
+            {
+                "name": "Mevcut Durum Analizi",
+                "description": f"{topic} alanındaki mevcut durum, temel kavramlar ve güncel gelişmeler",
+                "research": True
+            },
+            {
+                "name": "Teknoloji ve Yöntemler",
+                "description": f"{topic} kapsamında kullanılan teknolojiler, yöntemler ve araçlar",
+                "research": True
+            },
+            {
+                "name": "Uygulama Alanları",
+                "description": f"{topic} konusunun pratik uygulama alanları ve gerçek dünya örnekleri",
+                "research": True
+            },
+            {
+                "name": "Fırsatlar ve Zorluklar",
+                "description": f"{topic} alanındaki fırsatlar, zorluklar ve çözüm önerileri",
+                "research": True
+            },
+            {
+                "name": "Sonuç ve Öneriler",
+                "description": "Araştırma bulgularının özeti, sonuçlar ve gelecek için öneriler",
+                "research": False
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary
- add a dedicated parser module with multiple strategies and a fallback structure factory
- update the planner prompt and planning routine to leverage the robust parser and fallback handling
- introduce a debugging script to inspect planner prompts and responses

## Testing
- python debug_test.py *(fails: ProxyError when contacting openrouter.ai)*
- python ui.py

------
https://chatgpt.com/codex/tasks/task_b_68cc62bb90ac832fa66f15dc9743b113