### PR TITLE
Fix additional research accumulation with None values

### DIFF
--- a/writer_agent.py
+++ b/writer_agent.py
@@ -134,7 +134,8 @@ class WriterAgent:
                 return state
             else:
                 updated_state = dict(state)
-                updated_state['additional_research'] = updated_state.get('additional_research', '') + additional_research
+                existing_research = updated_state.get('additional_research') or ""
+                updated_state['additional_research'] = existing_research + additional_research
                 return updated_state
         
         async def write_section(state):


### PR DESCRIPTION
## Summary
- prevent None values from causing concatenation errors when storing additional research text in the writer agent

## Testing
- python -m compileall writer_agent.py

------
https://chatgpt.com/codex/tasks/task_b_68cc6cf96480832fab18303ff342699d