### PR TITLE
Fix async generator return path for empty topic

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -248,13 +248,14 @@ async def run_report(topic: str):
     """Gelişmiş rapor oluşturma fonksiyonu"""
     cleaned_topic = (topic or "").strip()
     if not cleaned_topic:
-        return (
+        yield (
             "❌ Lütfen bir rapor konusu girin.",
             "",
             None,
             update_progress_display(create_progress_steps()),
             get_recent_logs()
         )
+        return
 
     # Progress steps başlat
     steps = create_progress_steps()


### PR DESCRIPTION
## Summary
- replace the invalid return statement in `run_report` with a yielded response so the async generator stays valid

## Testing
- python -m compileall ui.py

------
https://chatgpt.com/codex/tasks/task_b_68cc73be3c7c832fa11d5230e49ef1fe