### PR TITLE
Fix periodic log updates for Gradio 5

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -439,8 +439,13 @@ def build_interface() -> gr.Blocks:
         # Otomatik log güncellemesi
         demo.load(
             update_ui_periodically,
-            outputs=log_display,
-            every=2  # Her 2 saniyede bir güncelle
+            outputs=log_display
+        )
+
+        log_timer = gr.Timer(interval=2)
+        log_timer.tick(
+            update_ui_periodically,
+            outputs=log_display
         )
         
         # Buton ve enter tuşu olayları


### PR DESCRIPTION
## Summary
- remove the deprecated `every` argument from the log updater load event
- add a `gr.Timer` that triggers the periodic log refresh to keep the UI updated on Gradio 5

## Testing
- python -m compileall ui.py

------
https://chatgpt.com/codex/tasks/task_b_68cc74b03244832fa3548a6a0c6abe92