### PR TITLE
Fix Gradio Timer initialization

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -442,7 +442,10 @@ def build_interface() -> gr.Blocks:
             outputs=log_display
         )
 
-        log_timer = gr.Timer(interval=2)
+        # Gradio 5.0+ Timer bileşeni "interval" yerine "value" parametresi kullanıyor.
+        # Daha eski sürümlerde de geriye dönük uyumluluk sağlamak için değer parametresi
+        # saniye cinsinden ayarlanıyor.
+        log_timer = gr.Timer(value=2)
         log_timer.tick(
             update_ui_periodically,
             outputs=log_display


### PR DESCRIPTION
## Summary
- replace deprecated Timer interval argument with value to match Gradio 5.x API
- document the parameter change to clarify compatibility rationale

## Testing
- python -m compileall Reporter_NVI/ui.py

------
https://chatgpt.com/codex/tasks/task_b_68cc7575494c832f976f5a0d34aebff6