### PR TITLE
feat: modular provider selection and UI enhancements

### DIFF
--- a/main_report_agent.py
+++ b/main_report_agent.py
@@ -14,7 +14,14 @@ from langgraph.graph import StateGraph, START, END
 import logging
 
 # Diğer modüllerden import
-from report_agent_setup import create_llm, search_web, Section, ReportStructure
+from report_agent_setup import (
+    create_llm,
+    create_search_tool,
+    Section,
+    ReportStructure,
+    DEFAULT_LLM_PROVIDER_ID,
+    DEFAULT_SEARCH_PROVIDERS,
+)
 from researcher_agent import ResearcherAgent
 from writer_agent import WriterAgent, ReportCompiler
 
@@ -198,12 +205,30 @@ class ReportAgentState:
 
 
 class MainReportAgent:
-    """Ana Rapor Ajan Sınıfı - Tüm sistemi yönetir"""
+    """Ana Rapor Ajan Sınıfı - Sağlayıcı seçimleri ile tüm sistemi yönetir"""
 
-    def __init__(self):
+    def __init__(
+        self,
+        llm_provider_id: Optional[str] = None,
+        search_provider_ids: Optional[List[str]] = None,
+    ):
+        # Sağlayıcı seçimlerini kaydet
+        self.llm_provider_id = llm_provider_id or DEFAULT_LLM_PROVIDER_ID
+        self.search_provider_ids = (
+            list(search_provider_ids)
+            if search_provider_ids
+            else list(DEFAULT_SEARCH_PROVIDERS)
+        )
+
         # Model ve araçları başlat
-        self.llm = create_llm()
-        self.search_tool = search_web
+        self.llm = create_llm(self.llm_provider_id)
+        self.search_tool = create_search_tool(self.search_provider_ids)
+
+        logger.info(
+            "LLM sağlayıcısı: %s | Arama sağlayıcıları: %s",
+            self.llm_provider_id,
+            ", ".join(self.search_provider_ids),
+        )
 
         # Alt ajanları başlat
         self.researcher = ResearcherAgent(self.llm, self.search_tool)

--- a/provider_manager.py
+++ b/provider_manager.py
@@ -1,0 +1,700 @@
+"""Provider yönetimi ve dinamik araç oluşturma yardımcıları.
+
+Bu modül, LLM ve arama sağlayıcılarını modüler şekilde yönetmek için
+soyut sınıflar ve fabrika yardımcıları sunar. Kullanıcılar runtime'da
+farklı sağlayıcı kombinasyonlarını seçebilir ve sistem bunları uygun
+LangChain nesnelerine dönüştürür.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import httpx
+from langchain_core.tools import tool
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SearchHit:
+    """Tek bir arama sonucunu temsil eder."""
+
+    title: str = "Başlık bulunamadı"
+    url: str = ""
+    snippet: str = ""
+
+
+@dataclass
+class SearchProviderResult:
+    """Arama sağlayıcısından dönen verileri tutar."""
+
+    provider_id: str
+    provider_name: str
+    query: str
+    hits: List[SearchHit] = field(default_factory=list)
+    summary: Optional[str] = None
+    error: Optional[str] = None
+
+
+class BaseProvider(ABC):
+    """Tüm sağlayıcılar için temel sınıf."""
+
+    provider_type: str = "generic"
+    provider_id: str = ""
+    display_name: str = ""
+    description: str = ""
+    strengths: Sequence[str] = ()
+    docs_url: Optional[str] = None
+    required_env_vars: Sequence[str] = ()
+    optional_env_vars: Sequence[str] = ()
+    default: bool = False
+
+    def metadata(self) -> Dict[str, Any]:
+        """Sağlayıcı hakkında UI'da gösterilecek meta bilgileri döndür."""
+
+        return {
+            "id": self.provider_id,
+            "name": self.display_name,
+            "type": self.provider_type,
+            "description": self.description,
+            "strengths": list(self.strengths),
+            "docs_url": self.docs_url,
+            "required_env_vars": list(self.required_env_vars),
+            "optional_env_vars": list(self.optional_env_vars),
+            "default": self.default,
+        }
+
+    def availability_status(self) -> Tuple[bool, Optional[str]]:
+        """Sağlayıcının kullanılabilirliğini ve gerekirse hata mesajını döndür."""
+
+        missing = [var for var in self.required_env_vars if not os.getenv(var)]
+        if missing:
+            message = "Eksik ortam değişkenleri: " + ", ".join(missing)
+            return False, message
+        return True, None
+
+    def is_available(self) -> bool:
+        """Sağlayıcı kullanılabilir mi?"""
+
+        ok, _ = self.availability_status()
+        return ok
+
+
+class BaseLLMProvider(BaseProvider):
+    """LLM sağlayıcıları için temel sınıf."""
+
+    provider_type = "llm"
+
+    @abstractmethod
+    def create_llm(self):
+        """LangChain uyumlu LLM örneği oluştur."""
+
+
+class BaseSearchProvider(BaseProvider):
+    """Arama sağlayıcıları için temel sınıf."""
+
+    provider_type = "search"
+    timeout: float = 30.0
+
+    def build_result(
+        self,
+        query: str,
+        *,
+        summary: Optional[str] = None,
+        hits: Optional[Iterable[Dict[str, Any]] | Iterable[SearchHit]] = None,
+        error: Optional[str] = None,
+    ) -> SearchProviderResult:
+        """Alt sınıflar için yardımcı sonuç oluşturucu."""
+
+        normalized_hits: List[SearchHit] = []
+
+        if hits:
+            for item in hits:
+                if isinstance(item, SearchHit):
+                    normalized_hits.append(item)
+                    continue
+
+                if isinstance(item, dict):
+                    title = str(item.get("title", "Başlık bulunamadı")).strip() or "Başlık bulunamadı"
+                    url = str(item.get("url", "")).strip()
+                    snippet = str(item.get("snippet", item.get("content", ""))).strip()
+                else:
+                    title = str(item)
+                    url = ""
+                    snippet = ""
+
+                normalized_hits.append(SearchHit(title=title, url=url, snippet=snippet))
+
+        return SearchProviderResult(
+            provider_id=self.provider_id,
+            provider_name=self.display_name,
+            query=query,
+            summary=summary,
+            hits=normalized_hits,
+            error=error,
+        )
+
+    async def search(
+        self,
+        query: str,
+        *,
+        topic: str = "general",
+        max_results: int = 5,
+    ) -> SearchProviderResult:
+        """Arama yap ve sonuç döndür."""
+
+        raise NotImplementedError
+
+
+class OpenRouterNemotronProvider(BaseLLMProvider):
+    """OpenRouter üzerinden NVIDIA Nemotron modeli."""
+
+    provider_id = "openrouter-nemotron"
+    display_name = "OpenRouter · NVIDIA Nemotron"
+    description = (
+        "OpenRouter API üzerinden NVIDIA Nemotron Nano 9B modelini"
+        " kullanır. Uygun maliyetli ve Türkçe performansı dengeli"
+        " bir seçenek sunar."
+    )
+    strengths = (
+        "Open-source NVIDIA Nemotron ailesi",
+        "OpenRouter kredileri ile erişim",
+        "Türkçe ve teknik içerikte stabil sonuçlar",
+    )
+    docs_url = "https://openrouter.ai/models/nvidia/nemotron-nano-9b-v2"
+    required_env_vars = ("OPENROUTER_API_KEY",)
+    optional_env_vars = ("MODEL_NAME", "MODEL_TEMPERATURE", "MODEL_MAX_TOKENS")
+    default = True
+
+    def availability_status(self) -> Tuple[bool, Optional[str]]:
+        ok, reason = super().availability_status()
+        if not ok:
+            return ok, reason
+        try:
+            import langchain_nvidia_ai_endpoints  # noqa: F401
+        except ImportError:
+            return False, "langchain-nvidia-ai-endpoints paketi gerekli"
+        return True, None
+
+    def create_llm(self):
+        from langchain_nvidia_ai_endpoints import ChatNVIDIA
+
+        model = os.getenv("MODEL_NAME", "nvidia/nemotron-nano-9b-v2:free")
+        temperature = float(os.getenv("MODEL_TEMPERATURE", "0.7"))
+        max_tokens = int(os.getenv("MODEL_MAX_TOKENS", "2000"))
+        api_key = os.getenv("OPENROUTER_API_KEY")
+
+        logger.info("OpenRouter Nemotron modeli yükleniyor: %s", model)
+        return ChatNVIDIA(
+            base_url="https://openrouter.ai/api/v1",
+            model=model,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+
+class OpenAIGPT4Provider(BaseLLMProvider):
+    """OpenAI GPT-4 ailesi için sağlayıcı."""
+
+    provider_id = "openai-gpt4"
+    display_name = "OpenAI · GPT-4o"
+    description = (
+        "OpenAI'nin GPT-4o ailesini kullanarak yüksek doğrulukta"
+        " yanıtlar üretir. Geniş eklenti ekosistemi ve gelişmiş"
+        " muhakeme yetenekleri sunar."
+    )
+    strengths = (
+        "Üst düzey muhakeme performansı",
+        "Zengin entegrasyon ve eklenti ekosistemi",
+        "Çok dilli içerikte güçlü sonuçlar",
+    )
+    docs_url = "https://platform.openai.com/docs/models"
+    required_env_vars = ("OPENAI_API_KEY",)
+    optional_env_vars = ("OPENAI_MODEL", "OPENAI_TEMPERATURE", "OPENAI_MAX_TOKENS")
+
+    def availability_status(self) -> Tuple[bool, Optional[str]]:
+        ok, reason = super().availability_status()
+        if not ok:
+            return ok, reason
+        try:
+            import langchain_openai  # noqa: F401
+        except ImportError:
+            return False, "langchain-openai paketi gerekli"
+        return True, None
+
+    def create_llm(self):
+        from langchain_openai import ChatOpenAI
+
+        api_key = os.getenv("OPENAI_API_KEY")
+        model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+        temperature = float(os.getenv("OPENAI_TEMPERATURE", os.getenv("MODEL_TEMPERATURE", "0.7")))
+        max_tokens = os.getenv("OPENAI_MAX_TOKENS", os.getenv("MODEL_MAX_TOKENS", None))
+
+        kwargs: Dict[str, Any] = {
+            "model": model,
+            "api_key": api_key,
+            "temperature": temperature,
+        }
+
+        if max_tokens is not None:
+            try:
+                kwargs["max_completion_tokens"] = int(max_tokens)
+            except ValueError:
+                logger.warning("OPENAI_MAX_TOKENS değeri sayıya çevrilemedi: %s", max_tokens)
+
+        logger.info("OpenAI GPT-4o modeli yükleniyor: %s", model)
+        return ChatOpenAI(**kwargs)
+
+
+class AnthropicClaudeProvider(BaseLLMProvider):
+    """Anthropic Claude modeli sağlayıcısı."""
+
+    provider_id = "anthropic-claude"
+    display_name = "Anthropic · Claude 3"
+    description = (
+        "Anthropic Claude 3 ailesi ile hızlı ve güvenli yanıtlar sağlar."
+        " Uzun bağlam ve güvenlik filtreleri ile kurumsal ihtiyaçlara"
+        " uygun yapı sunar."
+    )
+    strengths = (
+        "Güvenlik odaklı tasarım",
+        "Uzun bağlam penceresi",
+        "Hızlı ve düşük maliyetli Haiku modeli",
+    )
+    docs_url = "https://docs.anthropic.com/claude/docs"
+    required_env_vars = ("ANTHROPIC_API_KEY",)
+    optional_env_vars = ("ANTHROPIC_MODEL", "ANTHROPIC_TEMPERATURE", "ANTHROPIC_MAX_TOKENS")
+
+    def availability_status(self) -> Tuple[bool, Optional[str]]:
+        ok, reason = super().availability_status()
+        if not ok:
+            return ok, reason
+        try:
+            import langchain_anthropic  # noqa: F401
+        except ImportError:
+            return False, "langchain-anthropic paketi gerekli"
+        return True, None
+
+    def create_llm(self):
+        from langchain_anthropic import ChatAnthropic
+
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        model = os.getenv("ANTHROPIC_MODEL", "claude-3-haiku-20240307")
+        temperature = float(os.getenv("ANTHROPIC_TEMPERATURE", os.getenv("MODEL_TEMPERATURE", "0.7")))
+        max_tokens = os.getenv("ANTHROPIC_MAX_TOKENS", os.getenv("MODEL_MAX_TOKENS", None))
+
+        kwargs: Dict[str, Any] = {
+            "model_name": model,
+            "temperature": temperature,
+            "api_key": api_key,
+        }
+
+        if max_tokens is not None:
+            try:
+                kwargs["max_tokens_to_sample"] = int(max_tokens)
+            except ValueError:
+                logger.warning("ANTHROPIC_MAX_TOKENS değeri sayıya çevrilemedi: %s", max_tokens)
+
+        logger.info("Anthropic Claude modeli yükleniyor: %s", model)
+        return ChatAnthropic(**kwargs)
+
+
+class TavilySearchProvider(BaseSearchProvider):
+    """Tavily arama API sağlayıcısı."""
+
+    provider_id = "tavily"
+    display_name = "Tavily Search"
+    description = "Web araması için optimize edilmiş Tavily API'si"
+    strengths = (
+        "Otomatik özet üretimi",
+        "Hızlı yanıt süresi",
+        "Özel arama başlıkları (news, finance) desteği",
+    )
+    docs_url = "https://docs.tavily.com/"
+    required_env_vars = ("TAVILY_API_KEY",)
+    optional_env_vars = ("SEARCH_MAX_RESULTS",)
+    default = True
+
+    async def search(
+        self,
+        query: str,
+        *,
+        topic: str = "general",
+        max_results: int = 5,
+    ) -> SearchProviderResult:
+        available, message = self.availability_status()
+        if not available:
+            return self.build_result(query, error=message)
+
+        payload = {
+            "api_key": os.getenv("TAVILY_API_KEY"),
+            "query": query,
+            "search_depth": "basic",
+            "include_answer": True,
+            "include_raw_content": False,
+            "max_results": max_results,
+            "topic": topic,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post("https://api.tavily.com/search", json=payload)
+                response.raise_for_status()
+                data = response.json()
+        except Exception as exc:
+            logger.error("Tavily arama hatası", exc_info=exc)
+            return self.build_result(query, error=str(exc))
+
+        hits = []
+        for item in data.get("results", [])[:max_results]:
+            hits.append(
+                {
+                    "title": item.get("title", "Başlık yok"),
+                    "url": item.get("url", ""),
+                    "snippet": (item.get("content", "") or "")[:500],
+                }
+            )
+
+        return self.build_result(query, summary=data.get("answer"), hits=hits)
+
+
+class ExaSearchProvider(BaseSearchProvider):
+    """EXA semantik arama sağlayıcısı."""
+
+    provider_id = "exa"
+    display_name = "Exa Semantic Search"
+    description = "Semantik web araması ve autoprompt desteği"
+    strengths = (
+        "Semantik benzerlik tabanlı sonuçlar",
+        "Kaynak çeşitliliği",
+        "Autoprompt ile daha iyi sorgular",
+    )
+    docs_url = "https://docs.exa.ai/reference/search"
+    required_env_vars = ("EXA_API_KEY",)
+
+    async def search(
+        self,
+        query: str,
+        *,
+        topic: str = "general",
+        max_results: int = 5,
+    ) -> SearchProviderResult:
+        available, message = self.availability_status()
+        if not available:
+            return self.build_result(query, error=message)
+
+        payload = {
+            "query": query,
+            "useAutoprompt": True,
+            "numResults": max_results,
+            "type": "neural",
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+            "x-api-key": os.getenv("EXA_API_KEY", ""),
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post("https://api.exa.ai/search", json=payload, headers=headers)
+                response.raise_for_status()
+                data = response.json()
+        except Exception as exc:
+            logger.error("Exa arama hatası", exc_info=exc)
+            return self.build_result(query, error=str(exc))
+
+        hits = []
+        for item in data.get("results", [])[:max_results]:
+            hits.append(
+                {
+                    "title": item.get("title", "Başlık yok"),
+                    "url": item.get("url", ""),
+                    "snippet": (item.get("text", "") or "")[:500],
+                }
+            )
+
+        return self.build_result(query, summary=data.get("summary"), hits=hits)
+
+
+class SerpAPISearchProvider(BaseSearchProvider):
+    """SerpAPI Google arama sağlayıcısı."""
+
+    provider_id = "serpapi"
+    display_name = "SerpAPI Google Search"
+    description = "Google SERP sonuçlarını sağlayan SerpAPI"
+    strengths = (
+        "Google sonuçlarına hızlı erişim",
+        "Zengin bilgi kartı desteği",
+        "Kaynak başına detaylı metadata",
+    )
+    docs_url = "https://serpapi.com/search-api"
+    required_env_vars = ("SERPAPI_API_KEY",)
+
+    async def search(
+        self,
+        query: str,
+        *,
+        topic: str = "general",
+        max_results: int = 5,
+    ) -> SearchProviderResult:
+        available, message = self.availability_status()
+        if not available:
+            return self.build_result(query, error=message)
+
+        params = {
+            "engine": "google",
+            "q": query,
+            "num": max_results,
+            "hl": "tr" if topic == "general" else "en",
+            "api_key": os.getenv("SERPAPI_API_KEY"),
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get("https://serpapi.com/search.json", params=params)
+                response.raise_for_status()
+                data = response.json()
+        except Exception as exc:
+            logger.error("SerpAPI arama hatası", exc_info=exc)
+            return self.build_result(query, error=str(exc))
+
+        hits = []
+        for item in data.get("organic_results", [])[:max_results]:
+            hits.append(
+                {
+                    "title": item.get("title", "Başlık yok"),
+                    "url": item.get("link", ""),
+                    "snippet": (item.get("snippet", "") or "")[:500],
+                }
+            )
+
+        summary = None
+        answer_box = data.get("answer_box")
+        if isinstance(answer_box, dict):
+            summary = answer_box.get("answer") or answer_box.get("snippet")
+
+        return self.build_result(query, summary=summary, hits=hits)
+
+
+class ProviderFactory:
+    """Sağlayıcı örneklerini yöneten fabrika sınıfı."""
+
+    LLM_PROVIDERS: Dict[str, type[BaseLLMProvider]] = {
+        OpenRouterNemotronProvider.provider_id: OpenRouterNemotronProvider,
+        OpenAIGPT4Provider.provider_id: OpenAIGPT4Provider,
+        AnthropicClaudeProvider.provider_id: AnthropicClaudeProvider,
+    }
+
+    SEARCH_PROVIDERS: Dict[str, type[BaseSearchProvider]] = {
+        TavilySearchProvider.provider_id: TavilySearchProvider,
+        ExaSearchProvider.provider_id: ExaSearchProvider,
+        SerpAPISearchProvider.provider_id: SerpAPISearchProvider,
+    }
+
+    DEFAULT_LLM_PROVIDER_ID = os.getenv("DEFAULT_LLM_PROVIDER", OpenRouterNemotronProvider.provider_id)
+    DEFAULT_SEARCH_PROVIDER_IDS = [
+        provider_id
+        for provider_id in (os.getenv("DEFAULT_SEARCH_PROVIDERS") or TavilySearchProvider.provider_id).split(",")
+        if provider_id.strip()
+    ]
+
+    @classmethod
+    def normalize_provider_id(cls, provider_id: Optional[str]) -> Optional[str]:
+        if provider_id is None:
+            return None
+        return provider_id.strip().lower() or None
+
+    @classmethod
+    def get_llm_provider(cls, provider_id: Optional[str] = None) -> BaseLLMProvider:
+        normalized = cls.normalize_provider_id(provider_id) or cls.DEFAULT_LLM_PROVIDER_ID
+        provider_cls = cls.LLM_PROVIDERS.get(normalized)
+        if not provider_cls:
+            raise ValueError(f"Bilinmeyen LLM sağlayıcısı: {provider_id}")
+        return provider_cls()
+
+    @classmethod
+    def get_search_providers(cls, provider_ids: Optional[Iterable[str]] = None) -> List[BaseSearchProvider]:
+        ids: List[str]
+        if provider_ids is None:
+            ids = cls.DEFAULT_SEARCH_PROVIDER_IDS or [TavilySearchProvider.provider_id]
+        else:
+            ids = []
+            for provider_id in provider_ids:
+                normalized = cls.normalize_provider_id(provider_id)
+                if normalized and normalized not in ids:
+                    ids.append(normalized)
+
+        providers: List[BaseSearchProvider] = []
+        for provider_id in ids:
+            provider_cls = cls.SEARCH_PROVIDERS.get(provider_id)
+            if not provider_cls:
+                logger.warning("Bilinmeyen arama sağlayıcısı atlandı: %s", provider_id)
+                continue
+            providers.append(provider_cls())
+
+        if not providers:
+            logger.warning("Geçerli arama sağlayıcısı bulunamadı, Tavily varsayılanı kullanılacak")
+            providers.append(TavilySearchProvider())
+
+        return providers
+
+    @classmethod
+    def create_llm(cls, provider_id: Optional[str] = None):
+        provider = cls.get_llm_provider(provider_id)
+        available, message = provider.availability_status()
+        if not available:
+            raise RuntimeError(f"LLM sağlayıcısı kullanılamıyor: {message}")
+        return provider.create_llm()
+
+    @classmethod
+    def create_search_tool(
+        cls,
+        provider_ids: Optional[Iterable[str]] = None,
+        *,
+        max_results: Optional[int] = None,
+    ):
+        providers = cls.get_search_providers(provider_ids)
+        if max_results is None:
+            try:
+                default_limit = int(os.getenv("SEARCH_MAX_RESULTS", "5"))
+            except ValueError:
+                default_limit = 5
+        else:
+            default_limit = max_results if max_results > 0 else 5
+
+        provider_names = ", ".join(provider.display_name for provider in providers)
+        logger.info("Arama sağlayıcıları yapılandırılıyor: %s", provider_names)
+
+        async def _execute_provider(
+            provider: BaseSearchProvider,
+            query: str,
+            topic: str,
+            limit: int,
+        ) -> SearchProviderResult:
+            available, message = provider.availability_status()
+            if not available:
+                return provider.build_result(query, error=message)
+
+            try:
+                return await provider.search(query, topic=topic, max_results=limit)
+            except Exception as exc:  # pragma: no cover - hata durumlarını logla
+                logger.error(
+                    "Arama sağlayıcısı hata verdi: %s", provider.provider_id, exc_info=exc
+                )
+                return provider.build_result(query, error=str(exc))
+
+        @tool(name="search_web", parse_docstring=True)
+        async def multi_search(
+            queries: List[str],
+            topic: str = "general",
+            max_results: Optional[int] = None,
+        ) -> str:
+            """Seçili sağlayıcılar ile paralel web araması yap.
+
+            Args:
+                queries: Çalıştırılacak arama sorguları listesi.
+                topic: Arama bağlamı (general, news, finance).
+                max_results: Sağlayıcı başına maksimum sonuç sayısı.
+
+            Returns:
+                str: Sağlayıcı bazında gruplanmış arama sonuçları.
+            """
+
+            effective_limit = (
+                max_results if isinstance(max_results, int) and max_results > 0 else default_limit
+            )
+
+            if not isinstance(effective_limit, int) or effective_limit <= 0:
+                effective_limit = default_limit
+
+            formatted_output: List[str] = ["=== ARAŞTIRMA SONUÇLARI ===", ""]
+
+            if isinstance(queries, str):
+                queries = [queries]
+
+            if not queries:
+                return "Arama yapılacak sorgu bulunamadı."
+
+            for query in queries:
+                formatted_output.append(f"Sorgu: {query}")
+
+                results = await asyncio.gather(
+                    *[
+                        _execute_provider(provider, query, topic, effective_limit)
+                        for provider in providers
+                    ]
+                )
+
+                for provider_result in results:
+                    formatted_output.append(f"[{provider_result.provider_name}]")
+
+                    if provider_result.error:
+                        formatted_output.append(f"⚠️ {provider_result.error}")
+                        formatted_output.append("")
+                        continue
+
+                    if provider_result.summary:
+                        formatted_output.append(f"Özet: {provider_result.summary}")
+
+                    for index, hit in enumerate(provider_result.hits[:effective_limit], 1):
+                        formatted_output.append(f"{index}. {hit.title}")
+                        if hit.url:
+                            formatted_output.append(f"   URL: {hit.url}")
+                        snippet = hit.snippet.strip()
+                        if snippet:
+                            trimmed = snippet[:400] + ("..." if len(snippet) > 400 else "")
+                            formatted_output.append(f"   İçerik: {trimmed}")
+
+                    formatted_output.append("")
+
+                formatted_output.append("")
+
+            return "\n".join(formatted_output).strip()
+
+        multi_search.metadata = {
+            "provider_ids": [provider.provider_id for provider in providers],
+            "provider_names": [provider.display_name for provider in providers],
+        }
+
+        return multi_search
+
+    @classmethod
+    def get_llm_provider_options(cls) -> List[Dict[str, Any]]:
+        options: List[Dict[str, Any]] = []
+        for provider_id, provider_cls in cls.LLM_PROVIDERS.items():
+            provider = provider_cls()
+            available, message = provider.availability_status()
+            meta = provider.metadata()
+            meta.update({
+                "available": available,
+                "availability_message": message,
+            })
+            options.append(meta)
+
+        options.sort(key=lambda item: (not item.get("default", False), item["name"]))
+        return options
+
+    @classmethod
+    def get_search_provider_options(cls) -> List[Dict[str, Any]]:
+        options: List[Dict[str, Any]] = []
+        for provider_id, provider_cls in cls.SEARCH_PROVIDERS.items():
+            provider = provider_cls()
+            available, message = provider.availability_status()
+            meta = provider.metadata()
+            meta.update({
+                "available": available,
+                "availability_message": message,
+            })
+            options.append(meta)
+
+        options.sort(key=lambda item: (not item.get("default", False), item["name"]))
+        return options
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,9 @@
 # Core LangChain components
 langchain-core>=0.1.0
 langchain-nvidia-ai-endpoints>=0.1.0
+# Ek LLM bağlayıcıları
+langchain-openai>=0.1.0
+langchain-anthropic>=0.1.0
 
 # LangGraph for agent workflow
 langgraph>=0.0.40

--- a/ui.py
+++ b/ui.py
@@ -14,21 +14,144 @@ import asyncio
 import logging
 import time
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, List, Optional, Sequence
 from queue import Queue
-import threading
 
 import gradio as gr
 from dotenv import load_dotenv
 
 from main_report_agent import MainReportAgent
+from report_agent_setup import (
+    DEFAULT_LLM_PROVIDER_ID,
+    DEFAULT_SEARCH_PROVIDERS,
+    get_llm_provider_options,
+    get_search_provider_options,
+)
 
 # Ortam değişkenlerini yükle
 load_dotenv()
 
 # Global değişkenler
 _agent: Optional[MainReportAgent] = None
+_agent_config: Optional[Dict[str, Sequence[str]]] = None
 _log_queue = Queue()
+
+
+LLM_PROVIDER_OPTIONS = get_llm_provider_options()
+SEARCH_PROVIDER_OPTIONS = get_search_provider_options()
+LLM_PROVIDER_MAP: Dict[str, Dict[str, Any]] = {option["id"]: option for option in LLM_PROVIDER_OPTIONS}
+SEARCH_PROVIDER_MAP: Dict[str, Dict[str, Any]] = {option["id"]: option for option in SEARCH_PROVIDER_OPTIONS}
+
+
+def _build_choice_label(option: Dict[str, Any]) -> str:
+    status = "Hazır" if option.get("available") else "API anahtarı gerekli"
+    return f"{option['name']} · {status}"
+
+
+LLM_CHOICES: List[tuple[str, str]] = [
+    (_build_choice_label(option), option["id"]) for option in LLM_PROVIDER_OPTIONS
+]
+
+SEARCH_CHOICES: List[tuple[str, str]] = [
+    (_build_choice_label(option), option["id"]) for option in SEARCH_PROVIDER_OPTIONS
+]
+
+
+def build_provider_table_html() -> str:
+    """LLM ve arama sağlayıcıları için bilgilendirici tablo oluştur."""
+
+    def render_section(options: Sequence[Dict[str, Any]]) -> str:
+        rows: List[str] = []
+        for option in options:
+            status_class = "ok" if option.get("available") else "warn"
+            status_label = (
+                "Hazır"
+                if option.get("available")
+                else option.get("availability_message") or "API anahtarı gerekli"
+            )
+
+            description = option.get("description")
+            strengths = option.get("strengths") or []
+            if strengths:
+                strengths_html = "".join(f"<li>{strength}</li>" for strength in strengths)
+            else:
+                strengths_html = "<li>Bilgi bulunmuyor</li>"
+
+            notes_parts: List[str] = []
+            if option.get("default"):
+                notes_parts.append("<span class='note-muted'>Varsayılan kombinasyon</span>")
+
+            docs_url = option.get("docs_url")
+            if docs_url:
+                notes_parts.append(
+                    f"<a href='{docs_url}' target='_blank' rel='noopener noreferrer'>Doküman</a>"
+                )
+
+            required_keys = option.get("required_env_vars") or []
+            if required_keys:
+                notes_parts.append(
+                    "<span class='note-muted'>Gerekli: "
+                    + ", ".join(required_keys)
+                    + "</span>"
+                )
+
+            optional_keys = option.get("optional_env_vars") or []
+            if optional_keys:
+                notes_parts.append(
+                    "<span class='note-muted'>Opsiyonel: "
+                    + ", ".join(optional_keys)
+                    + "</span>"
+                )
+
+            if (not option.get("available")) and option.get("availability_message"):
+                notes_parts.append(
+                    f"<span class='note-muted'>{option['availability_message']}</span>"
+                )
+
+            if not notes_parts:
+                notes_parts.append("<span class='note-muted'>Ek gereksinim yok</span>")
+
+            notes_html = "<br>".join(notes_parts)
+
+            rows.append(
+                "<tr>"
+                + "<td>"
+                + f"<span class='provider-name'>{option['name']}</span>"
+                + f"<span class='status-pill {status_class}'>{status_label}</span>"
+                + (f"<div class='note-muted'>{description}</div>" if description else "")
+                + "</td>"
+                + f"<td><ul>{strengths_html}</ul></td>"
+                + f"<td>{notes_html}</td>"
+                + "</tr>"
+            )
+
+        return "".join(rows)
+
+    html_parts: List[str] = ["<div class='status-card provider-info'>"]
+    html_parts.append("<h3>⚙️ Sağlayıcı Karşılaştırması</h3>")
+
+    html_parts.append("<div class='provider-section'>")
+    html_parts.append("<h4>LLM Sağlayıcıları</h4>")
+    html_parts.append(
+        "<table class='provider-table'>"
+        "<thead><tr><th>Sağlayıcı</th><th>Güçlü Yönler</th><th>Notlar</th></tr></thead>"
+        "<tbody>"
+    )
+    html_parts.append(render_section(LLM_PROVIDER_OPTIONS))
+    html_parts.append("</tbody></table></div>")
+
+    html_parts.append("<div class='provider-section'>")
+    html_parts.append("<h4>Arama Sağlayıcıları</h4>")
+    html_parts.append(
+        "<table class='provider-table'>"
+        "<thead><tr><th>Sağlayıcı</th><th>Güçlü Yönler</th><th>Notlar</th></tr></thead>"
+        "<tbody>"
+    )
+    html_parts.append(render_section(SEARCH_PROVIDER_OPTIONS))
+    html_parts.append("</tbody></table></div>")
+
+    html_parts.append("</div>")
+    return "".join(html_parts)
 
 # Custom CSS
 CUSTOM_CSS = """
@@ -121,6 +244,61 @@ CUSTOM_CSS = """
     padding: 15px;
     color: #166534;
 }
+
+.provider-info {
+    margin-top: 10px;
+}
+
+.provider-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 12px;
+}
+
+.provider-table th,
+.provider-table td {
+    border: 1px solid #e2e8f0;
+    padding: 10px 12px;
+    vertical-align: top;
+    font-size: 14px;
+}
+
+.provider-table th {
+    background: #f8fafc;
+    color: #1f2937;
+}
+
+.provider-name {
+    font-weight: 600;
+    display: block;
+    margin-bottom: 6px;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 9999px;
+}
+
+.status-pill.ok {
+    background: rgba(34, 197, 94, 0.12);
+    color: #15803d;
+}
+
+.status-pill.warn {
+    background: rgba(234, 179, 8, 0.12);
+    color: #b45309;
+}
+
+.note-muted {
+    color: #64748b;
+    font-size: 12px;
+    margin-top: 6px;
+}
 """
 
 class LogCapture(logging.Handler):
@@ -153,12 +331,59 @@ def setup_logging():
         logger.addHandler(handler)
         logger.setLevel(logging.INFO)
 
-def _get_agent() -> MainReportAgent:
+def _normalize_search_selection(selection: Optional[Sequence[str]]) -> List[str]:
+    """Kullanıcıdan gelen arama sağlayıcı seçimini normalize et."""
+
+    if selection is None:
+        return list(DEFAULT_SEARCH_PROVIDERS)
+
+    if isinstance(selection, str):
+        normalized = [selection]
+    else:
+        normalized = [str(item) for item in selection if item]
+
+    return normalized or list(DEFAULT_SEARCH_PROVIDERS)
+
+
+def _get_agent(
+    llm_provider_id: Optional[str] = None,
+    search_provider_ids: Optional[Sequence[str]] = None,
+) -> MainReportAgent:
     """MainReportAgent örneğini tekil olacak şekilde döndür."""
-    global _agent
-    if _agent is None:
-        _agent = MainReportAgent()
+
+    global _agent, _agent_config
+
+    normalized_llm = llm_provider_id or DEFAULT_LLM_PROVIDER_ID
+    normalized_search = tuple(_normalize_search_selection(search_provider_ids))
+
+    config_signature = {"llm": normalized_llm, "search": normalized_search}
+
+    if _agent is None or _agent_config != config_signature:
+        _agent = MainReportAgent(
+            llm_provider_id=normalized_llm,
+            search_provider_ids=list(normalized_search),
+        )
+        _agent_config = config_signature
+
     return _agent
+
+
+def _format_provider_display(
+    provider_id: str,
+    provider_map: Dict[str, Dict[str, Any]],
+) -> str:
+    option = provider_map.get(provider_id)
+    if not option:
+        return provider_id
+    status = "✅" if option.get("available") else "⚠️"
+    return f"{status} {option['name']}"
+
+
+def _format_search_display(provider_ids: Sequence[str]) -> str:
+    if not provider_ids:
+        return "-"
+    names = [_format_provider_display(pid, SEARCH_PROVIDER_MAP) for pid in provider_ids]
+    return ", ".join(names)
 
 def _sanitize_topic(topic: str) -> str:
     """Dosya adı için konu başlığını güvenli formata getir."""
@@ -244,12 +469,25 @@ def get_recent_logs(max_logs=10):
     html += '</div></div>'
     return html
 
-async def run_report(topic: str):
+async def run_report(
+    topic: str,
+    llm_provider_id: Optional[str],
+    search_provider_ids: Optional[Sequence[str]],
+):
     """Gelişmiş rapor oluşturma fonksiyonu"""
+
     cleaned_topic = (topic or "").strip()
+    selected_llm = llm_provider_id or DEFAULT_LLM_PROVIDER_ID
+    selected_search = _normalize_search_selection(search_provider_ids)
+
+    provider_summary = (
+        f"LLM: {_format_provider_display(selected_llm, LLM_PROVIDER_MAP)}\n"
+        f"Arama: {_format_search_display(selected_search)}"
+    )
+
     if not cleaned_topic:
         yield (
-            "❌ Lütfen bir rapor konusu girin.",
+            "❌ Lütfen bir rapor konusu girin.\n" + provider_summary,
             "",
             None,
             update_progress_display(create_progress_steps()),
@@ -259,21 +497,21 @@ async def run_report(topic: str):
 
     # Progress steps başlat
     steps = create_progress_steps()
-    
+
     # Adım 1: Başlatma
     steps[0]["status"] = "active"
     yield (
-        "🚀 Sistem başlatılıyor...",
+        "🚀 Sistem başlatılıyor...\n" + provider_summary,
         "",
         None,
         update_progress_display(steps),
         get_recent_logs()
     )
-    
+
     try:
-        agent = _get_agent()
+        agent = _get_agent(selected_llm, selected_search)
         steps[0]["status"] = "completed"
-        
+
         # Adım 2: Araştırma
         steps[1]["status"] = "active"
         yield (
@@ -283,17 +521,17 @@ async def run_report(topic: str):
             update_progress_display(steps),
             get_recent_logs()
         )
-        
+
         # Rapor oluşturma - log takibi için
         start_time = time.time()
         report = await agent.generate_report(cleaned_topic)
-        
+
         if not report or report.strip().lower().startswith("hata"):
             # Hata durumu
             for step in steps:
                 if step["status"] == "active":
                     step["status"] = "error"
-            
+
             error_msg = report if report else "Rapor oluşturulamadı. Lütfen tekrar deneyin."
             yield (
                 f"❌ {error_msg}",
@@ -303,11 +541,11 @@ async def run_report(topic: str):
                 get_recent_logs()
             )
             return
-        
+
         # Tüm adımları tamamlandı olarak işaretle
         for step in steps[:-1]:  # Son adım hariç
             step["status"] = "completed"
-        
+
         steps[-1]["status"] = "active"  # Kaydetme adımı
         yield (
             "💾 Rapor kaydediliyor...",
@@ -316,20 +554,20 @@ async def run_report(topic: str):
             update_progress_display(steps),
             get_recent_logs()
         )
-        
+
         # Dosya kaydetme
         filename = _sanitize_topic(cleaned_topic)
         filepath = await agent.save_report(report, filename=filename)
-        
+
         steps[-1]["status"] = "completed"
-        
+
         # Başarılı tamamlama
         elapsed_time = time.time() - start_time
         success_message = f"✅ Rapor başarıyla oluşturuldu! ({elapsed_time:.1f} saniye)"
-        
+
         if filepath:
             success_message += f"\n📁 Dosya: {os.path.basename(filepath)}"
-        
+
         yield (
             success_message,
             report,
@@ -337,13 +575,13 @@ async def run_report(topic: str):
             update_progress_display(steps),
             get_recent_logs()
         )
-        
+
     except Exception as e:
         # Genel hata yakalama
         for step in steps:
             if step["status"] == "active":
                 step["status"] = "error"
-        
+
         error_message = f"❌ Beklenmeyen hata: {str(e)}"
         yield (
             error_message,
@@ -357,7 +595,7 @@ def build_interface() -> gr.Blocks:
     """Gelişmiş Gradio arayüzü oluştur"""
     
     with gr.Blocks(title="NVIDIA Rapor Ajanı", css=CUSTOM_CSS, theme=gr.themes.Soft()) as demo:
-        
+
         # Ana başlık
         gr.HTML("""
         <div class="header-section">
@@ -366,11 +604,28 @@ def build_interface() -> gr.Blocks:
             <p><em>Web araştırması yaparak kapsamlı Markdown raporları oluşturur</em></p>
         </div>
         """)
-        
+
+        gr.HTML(build_provider_table_html())
+
         with gr.Row():
             with gr.Column(scale=2):
                 # Giriş bölümü
                 with gr.Group():
+                    llm_dropdown = gr.Dropdown(
+                        choices=LLM_CHOICES,
+                        value=DEFAULT_LLM_PROVIDER_ID,
+                        label="🧠 LLM Sağlayıcısı",
+                        info="Raporun yazımında kullanılacak büyük dil modelini seçin.",
+                    )
+
+                    search_dropdown = gr.Dropdown(
+                        choices=SEARCH_CHOICES,
+                        value=list(DEFAULT_SEARCH_PROVIDERS),
+                        label="🔎 Arama Sağlayıcıları",
+                        info="Bir veya birden fazla web arama sağlayıcısı seçin.",
+                        multiselect=True,
+                    )
+
                     topic_input = gr.Textbox(
                         label="📝 Rapor Konusu",
                         placeholder="Örn. 'Yapay zeka ajanlarının sağlık sektöründeki uygulamaları'",
@@ -454,13 +709,13 @@ def build_interface() -> gr.Blocks:
         # Buton ve enter tuşu olayları
         generate_button.click(
             run_report,
-            inputs=topic_input,
+            inputs=[topic_input, llm_dropdown, search_dropdown],
             outputs=[status_message, report_output, download_output, progress_display, log_display]
         )
-        
+
         topic_input.submit(
             run_report,
-            inputs=topic_input,
+            inputs=[topic_input, llm_dropdown, search_dropdown],
             outputs=[status_message, report_output, download_output, progress_display, log_display]
         )
         


### PR DESCRIPTION
## Summary
- add a provider manager that wraps multiple LLM and web search services and exposes a parallel multi-provider LangChain tool
- refactor setup and main agent wiring to read provider choices from configuration while keeping Nemotron + Tavily as the default combo
- enhance the Gradio UI with provider dropdowns, a comparison table, and updated documentation for optional API keys

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68cc78af8f84832f96a2138d93cdd26c