### PR TITLE
Refine provider factory integration

### DIFF
--- a/main_report_agent.py
+++ b/main_report_agent.py
@@ -14,9 +14,8 @@ from langgraph.graph import StateGraph, START, END
 import logging
 
 # Diğer modüllerden import
+from provider_manager import ProviderFactory
 from report_agent_setup import (
-    create_llm,
-    create_search_tool,
     Section,
     ReportStructure,
     DEFAULT_LLM_PROVIDER_ID,
@@ -221,8 +220,8 @@ class MainReportAgent:
         )
 
         # Model ve araçları başlat
-        self.llm = create_llm(self.llm_provider_id)
-        self.search_tool = create_search_tool(self.search_provider_ids)
+        self.llm = ProviderFactory.create_llm(self.llm_provider_id)
+        self.search_tool = ProviderFactory.create_search_tool(self.search_provider_ids)
 
         logger.info(
             "LLM sağlayıcısı: %s | Arama sağlayıcıları: %s",

--- a/ui.py
+++ b/ui.py
@@ -21,11 +21,10 @@ import gradio as gr
 from dotenv import load_dotenv
 
 from main_report_agent import MainReportAgent
+from provider_manager import ProviderFactory
 from report_agent_setup import (
     DEFAULT_LLM_PROVIDER_ID,
     DEFAULT_SEARCH_PROVIDERS,
-    get_llm_provider_options,
-    get_search_provider_options,
 )
 
 # Ortam değişkenlerini yükle
@@ -37,8 +36,8 @@ _agent_config: Optional[Dict[str, Sequence[str]]] = None
 _log_queue = Queue()
 
 
-LLM_PROVIDER_OPTIONS = get_llm_provider_options()
-SEARCH_PROVIDER_OPTIONS = get_search_provider_options()
+LLM_PROVIDER_OPTIONS = ProviderFactory.get_llm_provider_options()
+SEARCH_PROVIDER_OPTIONS = ProviderFactory.get_search_provider_options()
 LLM_PROVIDER_MAP: Dict[str, Dict[str, Any]] = {option["id"]: option for option in LLM_PROVIDER_OPTIONS}
 SEARCH_PROVIDER_MAP: Dict[str, Dict[str, Any]] = {option["id"]: option for option in SEARCH_PROVIDER_OPTIONS}
 


### PR DESCRIPTION
## Summary
- update `MainReportAgent` to obtain LLM and search tool instances through `ProviderFactory`
- adjust the Gradio UI to pull provider options directly from `ProviderFactory`

## Testing
- python -m compileall main_report_agent.py ui.py provider_manager.py report_agent_setup.py

------
https://chatgpt.com/codex/tasks/task_b_68cc8215188c832f8332cd87e667c498