### PR TITLE
Handle dict tool call arguments for search tools

### DIFF
--- a/researcher_agent.py
+++ b/researcher_agent.py
@@ -102,8 +102,36 @@ class ResearcherAgent:
                 if tool_call['name'] == 'search_web':
                     # Araç argümanlarını parse et
                     import json
-                    args = json.loads(tool_call['args'])
-                    
+
+                    raw_args = tool_call.get('args', {})
+
+                    if isinstance(raw_args, dict):
+                        args = raw_args
+                    elif isinstance(raw_args, str):
+                        raw_args = raw_args.strip()
+                        if raw_args:
+                            try:
+                                parsed_args = json.loads(raw_args)
+                            except json.JSONDecodeError:
+                                logger.warning(
+                                    "Araç argümanları JSON olarak parse edilemedi, string kullanılacak: %s",
+                                    raw_args,
+                                )
+                                parsed_args = raw_args
+                            if isinstance(parsed_args, dict):
+                                args = parsed_args
+                            elif isinstance(parsed_args, list):
+                                args = {"queries": parsed_args}
+                            else:
+                                args = {"queries": [parsed_args]}
+                        else:
+                            args = {}
+                    else:
+                        logger.warning(
+                            "Araç argümanları beklenmeyen tipte: %s", type(raw_args).__name__
+                        )
+                        args = {}
+
                     # Web araması yap
                     result = await self.search_tool.ainvoke(args)
                     


### PR DESCRIPTION
## Summary
- normalize tool call arguments for the `search_web` tool when they are already structured dictionaries
- add resilient fallbacks so researcher and writer agents can execute Tavily searches under Claude

## Testing
- python -m compileall Reporter_NVI

------
https://chatgpt.com/codex/tasks/task_b_68cdc7276120832f8c9fc5bbfd477286