### PR TITLE
Improve report compilation robustness and formatting

### DIFF
--- a/quality_control_agent.py
+++ b/quality_control_agent.py
@@ -246,8 +246,9 @@ Düzeltilmiş raporu ver:""")
 
     def _basic_cleanup(self, text: str) -> str:
         """Temel temizlik işlemleri"""
-        # Non-printable karakterleri temizle
-        text = re.sub(r'[^\x20-\x7E\u00A0-\u017F\u0100-\u024F\u1E00-\u1EFF]', '', text)
+        # Non-printable karakterleri temizle (ancak satır sonlarını koru)
+        allowed_char_pattern = r'[^\x09\x0A\x0D\x20-\x7E\u00A0-\u017F\u0100-\u024F\u1E00-\u1EFF]'
+        text = re.sub(allowed_char_pattern, '', text)
 
         # Broken HTML anchor tags düzelt
         text = re.sub(r'<a name="([^"]*)"[^>]*>([^<]*)</a>', r'## \2', text)


### PR DESCRIPTION
## Summary
- preserve newline characters during basic cleanup so markdown structure stays intact
- add robustness checks and manual fallback assembly when the LLM compiler produces truncated reports
- generate consistent report scaffolding (title, içindekiler, giriş, sonuç) when falling back to manual compilation

## Testing
- python -m compileall writer_agent.py quality_control_agent.py

------
https://chatgpt.com/codex/tasks/task_b_68cebc3a4308832fb31b600b0988af83